### PR TITLE
Fix up package paths for some imports, update to Oauth2

### DIFF
--- a/googleapi.go
+++ b/googleapi.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"code.google.com/p/goauth2/oauth"
-	urlshortener "code.google.com/p/google-api-go-client/urlshortener/v1"
+	oauth "golang.org/x/oauth2"
+	urlshortener "google.golang.org/api/urlshortener/v1"
 	//"encoding/json"
 	//"fmt"
 	"github.com/kballard/goirc/irc"
@@ -15,8 +15,10 @@ import (
 func init() {
 	RegisterModule("googleapi", func() Module {
 		oc := &oauth.Config{
-			AuthURL:  "https://accounts.google.com/o/oauth2/auth",
-			TokenURL: "https://accounts.google.com/o/oauth2/token",
+			Endpoint: oauth.Endpoint{
+				AuthURL:  "https://accounts.google.com/o/oauth2/auth",
+				TokenURL: "https://accounts.google.com/o/oauth2/token",
+			},
 		}
 		return &GoogleApiMod{config: oc}
 	})
@@ -28,9 +30,9 @@ type GoogleApiMod struct {
 
 func (g *GoogleApiMod) Init(b *Bot, conn irc.SafeConn) error {
 	conf := b.Config.Search("mod", "googleapi")
-	g.config.ClientId = conf.Search("clientid")
+	g.config.ClientID = conf.Search("clientid")
 	g.config.ClientSecret = conf.Search("clientsecret")
-	g.config.Scope = urlshortener.UrlshortenerScope
+	g.config.Scopes = []string{urlshortener.UrlshortenerScope}
 
 	log.Printf("googleapi module initialized")
 	return nil

--- a/urlshorten.go
+++ b/urlshorten.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	urlshortener "code.google.com/p/google-api-go-client/urlshortener/v1"
+	urlshortener "google.golang.org/api/urlshortener/v1"
 	"fmt"
 	"github.com/kballard/goirc/irc"
 	"log"


### PR DESCRIPTION
A few of the packages changed import paths and the oauth library seems to have been made obsolete by the release of Oauth2.